### PR TITLE
feat: make file uploads public

### DIFF
--- a/src/controllers/File/createFile.js
+++ b/src/controllers/File/createFile.js
@@ -8,6 +8,7 @@ export async function create(req, res) {
     metadata: {
       contentType: file.mimetype,
     },
+    public: true,
   });
   blobWriter.on("error", (err) => {
     res.status(400).send(err);


### PR DESCRIPTION
## Description 

Deixei  o upload de imagens público. Antes era necessário realizar autenticação para abrir a imagem, agora basta acessar o link conforme sugerido pelo Davi.